### PR TITLE
Remove duplicate download button and block dialog after download

### DIFF
--- a/doc-viewer.js
+++ b/doc-viewer.js
@@ -39,11 +39,22 @@ function addButtons(){
 		}else{
 			buttons.push(button1.cloneNode(true, true));
 			buttons[i].onclick = function() {downloadDoc()};
+			prev_buttons[0].parentNode.parentNode.style.padding = "0px 0px";
 			prev_buttons[0].parentNode.parentNode.prepend(buttons[i]);
 			prev_buttons[0].parentNode.remove();
 			i++;
 		}
 		prev_buttons = document.getElementsByClassName("fa-cloud-arrow-down");
+	}
+	buttons.forEach(btn => {
+		btn.addEventListener('click', event => {
+			event.preventDefault();
+			event.stopPropagation();
+		});
+	});
+	const dialog = document.querySelector('#modal-overlay');
+	if (dialog) {
+		dialog.style.display = 'none';
 	}
 }
 


### PR DESCRIPTION
This commit removes the duplicate download button and the dialog after clicking the download button, which are shown below
![image](https://github.com/isanchop/stuhack/assets/59555509/c9e1e939-ca17-45e0-8a74-b07ec4486662)
